### PR TITLE
Fixed error where Gemini CLI could not download papers with their ID

### DIFF
--- a/src/arxiv_api.py
+++ b/src/arxiv_api.py
@@ -4,27 +4,34 @@ from datetime import datetime
 
 ARXIV_API_URL = "http://export.arxiv.org/api/query"
 
-def search_arxiv(query=None, author=None, title=None, max_results=10, start_date=None, end_date=None, start=0):
-    search_parts = []
-    if query:
-        search_parts.append(query)
-    if author:
-        search_parts.append(f"au:{author}")
-    if title:
-        search_parts.append(f"ti:{title}")
+def search_arxiv(query=None, author=None, title=None, id_list=None, max_results=10, start_date=None, end_date=None, start=0):
+    if id_list:
+        params = {
+            "id_list": ",".join(id_list) if isinstance(id_list, list) else id_list,
+            "max_results": max_results,
+            "start": start
+        }
+    else:
+        search_parts = []
+        if query:
+            search_parts.append(query)
+        if author:
+            search_parts.append(f"au:{author}")
+        if title:
+            search_parts.append(f"ti:{title}")
 
-    if not search_parts:
-        raise ValueError("At least one search parameter (query, author, or title) must be provided.")
+        if not search_parts:
+            raise ValueError("At least one search parameter (query, author, title, or id_list) must be provided.")
 
-    combined_query = " AND ".join(search_parts)
+        combined_query = " AND ".join(search_parts)
 
-    params = {
-        "search_query": combined_query,
-        "max_results": max_results,
-        "sortBy": "relevance",
-        "sortOrder": "descending",
-        "start": start
-    }
+        params = {
+            "search_query": combined_query,
+            "max_results": max_results,
+            "sortBy": "relevance",
+            "sortOrder": "descending",
+            "start": start
+        }
 
     # Add date range to query if provided
     if start_date and end_date:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -95,7 +95,7 @@ def perform_cli_download(arxiv_id):
     print(f"Attempting to download paper with arXiv ID: {arxiv_id}")
     try:
         # Search for the paper by its ID
-        papers = search_arxiv(query=f"id:{arxiv_id}", max_results=1)
+        papers = search_arxiv(id_list=arxiv_id, max_results=1)
         if papers:
             paper = papers[0]
             if paper['pdf_url']:


### PR DESCRIPTION
### Update

The structural discontinuity manifested in the access process of the Gemini CLI - specifically in the inability to extract documentary entities via their identificatory signature - was transformed by an operative intervention in the query logging interface. What previously appeared as a dysfunctional void in the process of digital text visualisation has now been returned to a coherent logic of addressability. This has not merely rectified a technical defect, but reconstituted a moment of epistemic mediation between signifier (ID) and documentary real (paper).

### What it means

* Fixed error where Gemini CLI could not download papers with their ID
